### PR TITLE
DRAFT: Enhancement: OpenTelemetry Messaging Specification

### DIFF
--- a/network_helpers.go
+++ b/network_helpers.go
@@ -1,0 +1,68 @@
+package messaging
+
+import (
+	"net"
+	"os"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+const ip_regex string = `(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)(\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)){3}`
+const host_or_ip_regex string = `@(\S+.*?):`
+const connString_password_regex string = `://\w*?:(.*?)@`
+const connString_regex string = `^amqp://\S+:\S+@\S+:\d*/$`
+const connString_port_regex = `:(\d+.*?)/`
+
+func isIPAddress(hostOrIpAddr string) (bool, string) {
+	regex := regexp.MustCompile(ip_regex)
+	match := regex.MatchString(hostOrIpAddr)
+	return match, hostOrIpAddr
+}
+
+func extractHostOrIPAddressFromConnectionString(connectionString string) string {
+	regex := regexp.MustCompile(host_or_ip_regex)
+	matches := regex.FindAllStringSubmatch(connectionString, -1)[0]
+	hostOrIpAddr := matches[1]
+	return hostOrIpAddr
+}
+
+func sanatizeConnectionString(connectionString string) string {
+	regex := regexp.MustCompile(connString_password_regex)
+	matches := regex.FindAllStringSubmatch(connectionString, -1)[0]
+	password := matches[1]
+	obfuscatedPassword := strings.Repeat("*", len(password))
+
+	return strings.Replace(connectionString, password, obfuscatedPassword, 1)
+}
+
+func isAMQPConnectionString(connectionString string) bool {
+	connStringRegex := regexp.MustCompile(connString_regex)
+	return connStringRegex.MatchString(connectionString)
+}
+
+func getPortFromConnectionString(connectionString string) int {
+	regex := regexp.MustCompile(connString_port_regex)
+	matches := regex.FindAllStringSubmatch(connectionString, -1)[0]
+	port, _ := strconv.Atoi(matches[0])
+	return port
+}
+
+func getPeerNames(ip string) []string {
+	hosts, _ := net.LookupAddr(ip)
+	return hosts
+}
+
+func getPeerAddresses(host string) []string {
+	ips, _ := net.LookupHost(host)
+	return ips
+}
+
+func joinNetworkTagValus(values []string) string {
+	return strings.Join(values, ",")
+}
+
+func getHostname() string {
+	hostname, _ := os.Hostname()
+	return hostname
+}

--- a/network_helpers.go
+++ b/network_helpers.go
@@ -20,7 +20,7 @@ func isIPAddress(hostOrIpAddr string) (bool, string) {
 	return match, hostOrIpAddr
 }
 
-func extractHostOrIPAddressFromConnectionString(connectionString string) string {
+func hostOrIPFromConnectionString(connectionString string) string {
 	regex := regexp.MustCompile(host_or_ip_regex)
 	matches := regex.FindAllStringSubmatch(connectionString, -1)[0]
 	hostOrIpAddr := matches[1]
@@ -44,7 +44,7 @@ func isAMQPConnectionString(connectionString string) bool {
 func getPortFromConnectionString(connectionString string) int {
 	regex := regexp.MustCompile(connString_port_regex)
 	matches := regex.FindAllStringSubmatch(connectionString, -1)[0]
-	port, _ := strconv.Atoi(matches[0])
+	port, _ := strconv.Atoi(matches[1])
 	return port
 }
 

--- a/otel.go
+++ b/otel.go
@@ -14,7 +14,7 @@ const consumerOperation string = "receive"
 const producerOperation string = "send"
 const temporaryDestination string = "(temporary)"
 
-func (producer *Producer) createPublishContext(ctx context.Context, config *ProducerConfiguration, queue *amqp.Queue, message amqp.Publishing) (context.Context, map[string]interface{}) {
+func (producer *Producer) createProducerContext(ctx context.Context, config *ProducerConfiguration, queue *amqp.Queue, message amqp.Publishing) (context.Context, map[string]interface{}) {
 	tracer := otel.Tracer("amqp")
 	destination := producer.buildProducerDestination(config, queue, message)
 	spanName := producer.buildProducerSpanName(destination, producerOperation)

--- a/otel.go
+++ b/otel.go
@@ -2,6 +2,7 @@ package messaging
 
 import (
 	"context"
+	"fmt"
 
 	amqp "github.com/rabbitmq/amqp091-go"
 	"go.opentelemetry.io/otel"
@@ -9,28 +10,32 @@ import (
 	"go.opentelemetry.io/otel/trace"
 )
 
+const consumerOperation string = "receive"
+const producerOperation string = "send"
+const temporaryDestination string = "(temporary)"
+
 func (producer *Producer) createPublishContext(ctx context.Context, config *ProducerConfiguration, queue *amqp.Queue, message amqp.Publishing) (context.Context, map[string]interface{}) {
 	tracer := otel.Tracer("amqp")
-
-	amqpContext, span := tracer.Start(ctx, "amqp - produce", trace.WithSpanKind(trace.SpanKindProducer))
-
-	destination := config.getExchange()
-
-	if destination == emptyExchangeName {
-		destination = queue.Name
-	}
-
-	peer_addr := producer.connection.LocalAddr().String()
+	destination := producer.buildProducerDestination(config, queue, message)
+	spanName := producer.buildProducerSpanName(destination, producerOperation)
+	producerContext, span := tracer.Start(ctx, spanName, trace.WithSpanKind(trace.SpanKindProducer))
 
 	span.SetAttributes(attribute.KeyValue{Key: "messaging.system", Value: attribute.StringValue("rabbitmq")})
+	span.SetAttributes(attribute.KeyValue{Key: "messaging.operation", Value: attribute.StringValue(producerOperation)})
 	span.SetAttributes(attribute.KeyValue{Key: "messaging.destination", Value: attribute.StringValue(destination)})
 	span.SetAttributes(attribute.KeyValue{Key: "messaging.destination_kind", Value: attribute.StringValue("queue")})
 	span.SetAttributes(attribute.KeyValue{Key: "messaging.protocol", Value: attribute.StringValue("AMQP")})
 	span.SetAttributes(attribute.KeyValue{Key: "messaging.protocol_version", Value: attribute.StringValue("0.9.1")})
-	span.SetAttributes(attribute.KeyValue{Key: "messaging.url", Value: attribute.StringValue(producer.connectionString)})
+
 	span.SetAttributes(attribute.KeyValue{Key: "messaging.message_id", Value: attribute.StringValue(message.MessageId)})
 	span.SetAttributes(attribute.KeyValue{Key: "messaging.message_payload_size_bytes", Value: attribute.IntValue(len(message.Body))})
-	span.SetAttributes(attribute.KeyValue{Key: "net.sock.peer.addr", Value: attribute.StringValue(peer_addr)})
+
+	if isAMQPConnectionString(producer.connectionString) {
+		sanatizedConnectionString := sanatizeConnectionString(producer.connectionString)
+		span.SetAttributes(attribute.KeyValue{Key: "messaging.url", Value: attribute.StringValue(sanatizedConnectionString)})
+
+		setNetworkTags(span, producer.connectionString)
+	}
 
 	if config.routingKey != "" {
 		span.SetAttributes(attribute.KeyValue{Key: "messaging.rabbitmq.routing_key", Value: attribute.StringValue(config.routingKey)})
@@ -38,38 +43,109 @@ func (producer *Producer) createPublishContext(ctx context.Context, config *Prod
 
 	defer span.End()
 
-	headers := producer.InjectAMQPHeaders(amqpContext)
+	headers := producer.InjectAMQPHeaders(producerContext)
 
-	return amqpContext, headers
+	return producerContext, headers
+}
+
+func setNetworkTags(span trace.Span, connectionString string) {
+	hostOrIp := extractHostOrIPAddressFromConnectionString(connectionString)
+	port := getPortFromConnectionString(connectionString)
+	hostName := getHostname()
+	span.SetAttributes(attribute.KeyValue{Key: "net.name", Value: attribute.StringValue(hostName)})
+	span.SetAttributes(attribute.KeyValue{Key: "net.sock.peer.port", Value: attribute.IntValue(port)})
+
+	if match, ip := isIPAddress(hostOrIp); match {
+		peerNames := getPeerNames(ip)
+		peerAddresses := getPeerAddresses(peerNames[0])
+		peer_name_value := joinNetworkTagValus(peerNames)
+		peer_addr_value := joinNetworkTagValus(peerAddresses)
+
+		span.SetAttributes(attribute.KeyValue{Key: "net.sock.peer.name", Value: attribute.StringValue(peer_name_value)})
+		span.SetAttributes(attribute.KeyValue{Key: "net.sock.peer.addr", Value: attribute.StringValue(peer_addr_value)})
+		return
+	}
+
+	if match, host := isIPAddress(hostOrIp); !match {
+		peerAddresses := getPeerAddresses(host)
+		peerNames := getPeerNames(peerAddresses[0])
+		peer_name_value := joinNetworkTagValus(peerNames)
+		peer_addr_value := joinNetworkTagValus(peerAddresses)
+
+		span.SetAttributes(attribute.KeyValue{Key: "net.sock.peer.name", Value: attribute.StringValue(peer_name_value)})
+		span.SetAttributes(attribute.KeyValue{Key: "net.sock.peer.addr", Value: attribute.StringValue(peer_addr_value)})
+		return
+	}
+}
+
+func (producer *Producer) buildProducerDestination(config *ProducerConfiguration, queue *amqp.Queue, message amqp.Publishing) string {
+	if config.QueueConfig != nil && config.QueueConfig.name != "" {
+		return config.QueueConfig.name
+	}
+
+	exchange := config.getExchange()
+
+	if exchange != emptyExchangeName {
+		return exchange
+	}
+
+	return temporaryDestination
+}
+
+func (producer *Producer) buildProducerSpanName(destination, operation string) string {
+	return fmt.Sprintf("%s %s", destination, operation)
 }
 
 func (consumer *Consumer) createConsumeContext(ctx context.Context, config *ConsumerConfiguration, message amqp.Delivery, key string) context.Context {
 	amqpContext := consumer.ExtractAMQPHeader(context.Background(), message.Headers)
 	tracer := otel.Tracer("amqp")
-	consumerContext, span := tracer.Start(amqpContext, "amqp - consume", trace.WithSpanKind(trace.SpanKindConsumer))
-
-	destination := key
-
-	if destination == emptyExchangeName {
-		destination = message.Exchange
-	}
-
-	peer_addr := consumer.connection.LocalAddr().String()
+	destination := consumer.buildConsumerDestination(config, message, key)
+	spanName := consumer.buildConsumerSpanName(destination, consumerOperation)
+	consumerContext, span := tracer.Start(amqpContext, spanName, trace.WithSpanKind(trace.SpanKindConsumer))
 
 	span.SetAttributes(attribute.KeyValue{Key: "messaging.system", Value: attribute.StringValue("rabbitmq")})
+	span.SetAttributes(attribute.KeyValue{Key: "messaging.operation", Value: attribute.StringValue(consumerOperation)})
 	span.SetAttributes(attribute.KeyValue{Key: "messaging.destination", Value: attribute.StringValue(destination)})
 	span.SetAttributes(attribute.KeyValue{Key: "messaging.destination_kind", Value: attribute.StringValue("queue")})
 	span.SetAttributes(attribute.KeyValue{Key: "messaging.protocol", Value: attribute.StringValue("AMQP")})
 	span.SetAttributes(attribute.KeyValue{Key: "messaging.protocol_version", Value: attribute.StringValue("0.9.1")})
-	span.SetAttributes(attribute.KeyValue{Key: "messaging.url", Value: attribute.StringValue(consumer.connectionString)})
+
 	span.SetAttributes(attribute.KeyValue{Key: "messaging.message_id", Value: attribute.StringValue(message.MessageId)})
 	span.SetAttributes(attribute.KeyValue{Key: "messaging.message_payload_size_bytes", Value: attribute.IntValue(len(message.Body))})
-	span.SetAttributes(attribute.KeyValue{Key: "net.sock.peer.addr", Value: attribute.StringValue(peer_addr)})
+
+	if isAMQPConnectionString(consumer.connectionString) {
+		sanatizedConnectionString := sanatizeConnectionString(consumer.connectionString)
+		span.SetAttributes(attribute.KeyValue{Key: "messaging.url", Value: attribute.StringValue(sanatizedConnectionString)})
+
+		setNetworkTags(span, consumer.connectionString)
+	}
 
 	if config.routingKey != "" {
 		span.SetAttributes(attribute.KeyValue{Key: "messaging.rabbitmq.routing_key", Value: attribute.StringValue(config.routingKey)})
 	}
+
 	defer span.End()
 
 	return consumerContext
+}
+
+func (consumer *Consumer) buildConsumerDestination(config *ConsumerConfiguration, message amqp.Delivery, key string) string {
+	if config.QueueConfig != nil && config.QueueConfig.name != "" {
+		return config.QueueConfig.name
+	}
+
+	if config.ExchangeConfig != nil && message.Exchange != emptyExchangeName {
+		return message.Exchange
+	}
+
+	if key != "" {
+		return key
+	}
+
+	return temporaryDestination
+}
+
+func (consumer *Consumer) buildConsumerSpanName(destination, operation string) string {
+	spanName := fmt.Sprintf("%s %s", destination, operation)
+	return spanName
 }

--- a/producer.go
+++ b/producer.go
@@ -54,7 +54,7 @@ func (producer *Producer) Produce(ctx context.Context, message any, configure Co
 		MessageId:    uuid.New().String(),
 	}
 
-	amqpContext, headers := producer.createPublishContext(ctx, config, queue, msg)
+	amqpContext, headers := producer.createProducerContext(ctx, config, queue, msg)
 
 	msg.Headers = headers
 


### PR DESCRIPTION
Based on the [OpenTelemetry Messaging Specification](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/messaging.md), the following changes were made:

- [x] correct use of span name
- [x] correct use of destination
- [x] correct use of network tags: `net.peer.name`, `net.sock.family`, `net.sock.peer.addr`, `net.sock.peer.name`, `net.sock.peer.port`